### PR TITLE
Fix default export for UI colors and branding colors

### DIFF
--- a/src/branding/branding-palette.ts
+++ b/src/branding/branding-palette.ts
@@ -64,3 +64,5 @@ export const {
     crimson,
     wine,
 } = BrandingColors;
+
+export default BrandingColors;

--- a/src/branding/index.ts
+++ b/src/branding/index.ts
@@ -1,1 +1,5 @@
 export * from './branding-palette';
+
+import BrandingColors from './branding-palette';
+
+export default BrandingColors;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
 export * from './palette';
+
+import Colors from './palette';
+
+export default Colors;

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -147,3 +147,16 @@ export const purple: Purple = {
     98: '#FFF7FF',
     100: '#FFFFFF',
 };
+
+const Colors = {
+    primary: primary,
+    neutral: neutral,
+    neutralVariant: neutralVariant,
+    error: error,
+    warning: warning,
+    success: success,
+    orange: orange,
+    purple: purple,
+};
+
+export default Colors;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 4939 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Export UI colors and Branding colors as a default
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-


<img width="1785" alt="Screenshot 2023-11-24 at 7 23 31 PM" src="https://github.com/etn-ccis/blui-colors/assets/133877691/617d2c8e-a043-4f57-88f7-893004054577">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Test it in RN showcase demo with new import

- Use this format to test 
<img width="621" alt="image-20231116-144449" src="https://github.com/etn-ccis/blui-colors/assets/133877691/9893efed-a06f-48eb-880e-2207a40d189d">

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
